### PR TITLE
Use EuiKeyPadMenuItem

### DIFF
--- a/src/plugins/ui_actions/public/components/action_wizard/action_wizard.scss
+++ b/src/plugins/ui_actions/public/components/action_wizard/action_wizard.scss
@@ -4,6 +4,7 @@
 }
 
 .uiaActionWizard__actionFactoryItem {
-  width: #{$euiSize * 7.5};
-  min-height: #{$euiSize * 6};
+  .euiKeyPadMenuItem__label {
+    height: #{$euiSizeXL};
+  }
 }

--- a/src/plugins/ui_actions/public/components/action_wizard/action_wizard.tsx
+++ b/src/plugins/ui_actions/public/components/action_wizard/action_wizard.tsx
@@ -26,6 +26,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiKeyPadMenuItem,
 } from '@elastic/eui';
 import { txtChangeButton } from './i18n';
 import './action_wizard.scss';
@@ -189,30 +190,18 @@ const ActionFactorySelector: React.FC<ActionFactorySelectorProps> = ({
   }
 
   return (
-    <EuiFlexGroup wrap={true}>
+    <EuiFlexGroup wrap>
       {actionFactories.map(actionFactory => (
-        <EuiFlexItem
+        <EuiKeyPadMenuItem
           className="uiaActionWizard__actionFactoryItem"
           grow={false}
           key={actionFactory.type}
+          label={actionFactory.displayName}
           data-test-subj={TEST_SUBJ_ACTION_FACTORY_ITEM}
+          onClick={() => onActionFactorySelected(actionFactory)}
         >
-          <EuiPanel
-            onClick={() => onActionFactorySelected(actionFactory)}
-            className="eui-textCenter"
-            paddingSize="s"
-          >
-            {actionFactory.iconType && (
-              <>
-                <EuiIcon type={actionFactory.iconType} size="m" />
-                <EuiSpacer size="s" />
-              </>
-            )}
-            <EuiText size="xs">
-              <h4>{actionFactory.displayName}</h4>
-            </EuiText>
-          </EuiPanel>
-        </EuiFlexItem>
+          {actionFactory.iconType && <EuiIcon type={actionFactory.iconType} size="m" />}
+        </EuiKeyPadMenuItem>
       ))}
     </EuiFlexGroup>
   );


### PR DESCRIPTION
## Summary

This PR updates the selection of actions to use `EuiKeyPadMenuItem`. 

I added a height to the label because we want the labels to be horizontally aligned even when some are 1 line and others are 2 lines. The result is this:

![image](https://user-images.githubusercontent.com/4016496/75825041-771bbb00-5d59-11ea-8302-532d5ccd4883.png)

vs

![image](https://user-images.githubusercontent.com/4016496/75825519-6586e300-5d5a-11ea-9033-f6093a17cae7.png)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

