### PR TITLE
experiment with useImperitiveHandle & forwardRef

### DIFF
--- a/examples/embeddable_explorer/public/todo_embeddable_example.tsx
+++ b/examples/embeddable_explorer/public/todo_embeddable_example.tsx
@@ -34,7 +34,7 @@ import {
   EuiTextArea,
   EuiTitle,
 } from '@elastic/eui';
-import { TodoInput } from '../../../examples/embeddable_examples/public/todo';
+import { TodoEmbeddable, TodoInput } from '../../../examples/embeddable_examples/public/todo';
 import { TodoEmbeddableFactory } from '../../../examples/embeddable_examples/public';
 import { EmbeddableRenderer } from '../../../src/plugins/embeddable/public';
 
@@ -50,24 +50,32 @@ interface State {
   input: TodoInput;
 }
 
+const initialInput: TodoInput = {
+  id: '1',
+  task: 'Take out the trash',
+  icon: 'broom',
+  title: 'Trash',
+};
+
 export class TodoEmbeddableExample extends React.Component<Props, State> {
+  private embeddableRef = React.createRef<TodoEmbeddable>();
+
   constructor(props: Props) {
     super(props);
 
     this.state = {
       loading: true,
-      input: {
-        id: '1',
-        task: 'Take out the trash',
-        icon: 'broom',
-        title: 'Trash',
-      },
+      input: initialInput,
     };
   }
 
   private onUpdateEmbeddableInput = () => {
     const { task, title, icon, input } = this.state;
     this.setState({ input: { ...input, task: task ?? '', title, icon } });
+
+    if (this.embeddableRef.current) {
+      this.embeddableRef.current.updateInput({ task: task ?? '', title, icon });
+    }
   };
 
   public render() {
@@ -128,6 +136,13 @@ export class TodoEmbeddableExample extends React.Component<Props, State> {
               <EmbeddableRenderer
                 factory={this.props.todoEmbeddableFactory}
                 input={this.state.input}
+              />
+            </EuiPanel>
+            <EuiPanel data-test-subj="todoEmbeddableImperative" paddingSize="none" role="figure">
+              <EmbeddableRenderer
+                factory={this.props.todoEmbeddableFactory}
+                input={initialInput}
+                ref={this.embeddableRef}
               />
             </EuiPanel>
           </EuiPageContentBody>


### PR DESCRIPTION
## Summary

Built on top of https://github.com/elastic/kibana/pull/67783/files

Experimenting with `useImperitiveHandler` & `forwardRef` to give access to underlying embeddable object

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

