### PR TITLE
[ES|QL] Change in the history time implementation

### DIFF
--- a/packages/kbn-esql-editor/src/editor_footer/esql_starred_queries_service.tsx
+++ b/packages/kbn-esql-editor/src/editor_footer/esql_starred_queries_service.tsx
@@ -6,7 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import moment from 'moment';
 import React from 'react';
 import { BehaviorSubject } from 'rxjs';
 import { i18n } from '@kbn/i18n';
@@ -17,14 +16,8 @@ import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { EuiButtonIcon } from '@elastic/eui';
 import { FavoritesClient } from '@kbn/content-management-favorites-public';
 import { FAVORITES_LIMIT as ESQL_STARRED_QUERIES_LIMIT } from '@kbn/content-management-favorites-common';
-import {
-  type QueryHistoryItem,
-  getMomentTimeZone,
-  getTrimmedQuery,
-} from '../history_local_storage';
+import { type QueryHistoryItem, getTrimmedQuery } from '../history_local_storage';
 import { TooltipWrapper } from './tooltip_wrapper';
-
-const ISO8601_TZ_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
 const STARRED_QUERIES_DISCARD_KEY = 'esqlEditor.starredQueriesDiscard';
 
@@ -116,13 +109,12 @@ export class EsqlStarredQueriesService {
     return this.starredQueries.length >= ESQL_STARRED_QUERIES_LIMIT;
   }
 
-  async addStarredQuery(item: QueryHistoryItem) {
-    const tz = getMomentTimeZone();
+  async addStarredQuery(item: Pick<QueryHistoryItem, 'queryString' | 'status'>) {
     const favoriteItem = {
       id: generateId(),
       metadata: {
         queryString: getTrimmedQuery(item.queryString),
-        timeRan: moment().tz(tz).format(ISO8601_TZ_FORMAT),
+        timeRan: new Date().toISOString(),
         status: item.status,
       },
     };

--- a/packages/kbn-esql-editor/src/editor_footer/history_starred_queries.test.tsx
+++ b/packages/kbn-esql-editor/src/editor_footer/history_starred_queries.test.tsx
@@ -25,7 +25,6 @@ jest.mock('../history_local_storage', () => {
     getHistoryItems: () => [
       {
         queryString: 'from kibana_sample_data_flights | limit 10',
-        timeZone: 'Browser',
         timeRan: 'Mar. 25, 24 08:45:27',
         queryRunning: false,
         status: 'success',

--- a/packages/kbn-esql-editor/src/esql_editor.tsx
+++ b/packages/kbn-esql-editor/src/esql_editor.tsx
@@ -91,7 +91,6 @@ export const ESQLEditor = memo(function ESQLEditor({
     fieldsMetadata,
     uiSettings,
   } = kibana.services;
-  const timeZone = core?.uiSettings?.get('dateFormat:tz');
   const histogramBarTarget = uiSettings?.get('histogram:barTarget') ?? 50;
   const [code, setCode] = useState<string>(query.esql ?? '');
   // To make server side errors less "sticky", register the state of the code when submitting
@@ -456,11 +455,10 @@ export const ESQLEditor = memo(function ESQLEditor({
       validateQuery();
       addQueriesToCache({
         queryString: code,
-        timeZone,
         status: clientParserStatus,
       });
     }
-  }, [clientParserStatus, isLoading, isQueryLoading, parseMessages, code, timeZone]);
+  }, [clientParserStatus, isLoading, isQueryLoading, parseMessages, code]);
 
   const queryValidation = useCallback(
     async ({ active }: { active: boolean }) => {

--- a/packages/kbn-esql-editor/src/history_local_storage.test.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.test.ts
@@ -20,7 +20,6 @@ describe('history local storage', function () {
   it('should add queries to cache correctly ', function () {
     addQueriesToCache({
       queryString: 'from kibana_sample_data_flights | limit 10',
-      timeZone: 'Browser',
     });
     const historyItems = getCachedQueries();
     expect(historyItems.length).toBe(1);
@@ -31,7 +30,6 @@ describe('history local storage', function () {
   it('should update queries to cache correctly ', function () {
     addQueriesToCache({
       queryString: 'from kibana_sample_data_flights \n | limit 10 \n | stats meow = avg(woof)',
-      timeZone: 'Browser',
       status: 'success',
     });
 
@@ -49,7 +47,6 @@ describe('history local storage', function () {
   it('should update queries to cache correctly if they are the same with different format', function () {
     addQueriesToCache({
       queryString: 'from kibana_sample_data_flights | limit 10 | stats meow = avg(woof)      ',
-      timeZone: 'Browser',
       status: 'success',
     });
 
@@ -68,7 +65,6 @@ describe('history local storage', function () {
     addQueriesToCache(
       {
         queryString: 'row 1',
-        timeZone: 'Browser',
         status: 'success',
       },
       2

--- a/packages/kbn-esql-editor/src/history_local_storage.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.ts
@@ -29,7 +29,9 @@ export const getTrimmedQuery = (queryString: string) => {
 
 const sortDates = (date1?: string, date2?: string) => {
   if (!date1 || !date2) return 0;
-  return date1 < date2 ? 1 : date1 > date2 ? -1 : 0;
+  const dateA = new Date(date1).toISOString();
+  const dateB = new Date(date2).toISOString();
+  return dateA < dateB ? 1 : dateA > dateB ? -1 : 0;
 };
 
 export const getHistoryItems = (sortDirection: 'desc' | 'asc'): QueryHistoryItem[] => {

--- a/packages/kbn-esql-editor/src/history_local_storage.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.ts
@@ -29,9 +29,7 @@ export const getTrimmedQuery = (queryString: string) => {
 
 const sortDates = (date1?: string, date2?: string) => {
   if (!date1 || !date2) return 0;
-  const dateA = new Date(date1).toISOString();
-  const dateB = new Date(date2).toISOString();
-  return dateA < dateB ? 1 : dateA > dateB ? -1 : 0;
+  return date1 < date2 ? 1 : date1 > date2 ? -1 : 0;
 };
 
 export const getHistoryItems = (sortDirection: 'desc' | 'asc'): QueryHistoryItem[] => {
@@ -62,7 +60,11 @@ export const addQueriesToCache = (
   const queries = getHistoryItems('desc');
   queries.forEach((queryItem) => {
     const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
-    cachedQueries.set(trimmedQueryString, queryItem);
+    const updatedQueryItem = {
+      ...queryItem,
+      timeRan: queryItem.timeRan ? new Date(queryItem.timeRan).toISOString() : undefined,
+    };
+    cachedQueries.set(trimmedQueryString, updatedQueryItem);
   });
   const trimmedQueryString = getTrimmedQuery(item.queryString);
 

--- a/packages/kbn-esql-editor/src/history_local_storage.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.ts
@@ -35,6 +35,12 @@ const sortDates = (date1?: string, date2?: string) => {
 export const getHistoryItems = (sortDirection: 'desc' | 'asc'): QueryHistoryItem[] => {
   const localStorageString = localStorage.getItem(QUERY_HISTORY_ITEM_KEY) ?? '[]';
   const historyItems: QueryHistoryItem[] = JSON.parse(localStorageString);
+
+  // for backwards compatibility
+  historyItems.forEach((item) => {
+    item.timeRan = item.timeRan ? new Date(item.timeRan).toISOString() : undefined;
+  });
+
   const sortedByDate = historyItems.sort((a, b) => {
     return sortDirection === 'desc'
       ? sortDates(b.timeRan, a.timeRan)
@@ -60,11 +66,7 @@ export const addQueriesToCache = (
   const queries = getHistoryItems('desc');
   queries.forEach((queryItem) => {
     const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
-    const updatedQueryItem = {
-      ...queryItem,
-      timeRan: queryItem.timeRan ? new Date(queryItem.timeRan).toISOString() : undefined,
-    };
-    cachedQueries.set(trimmedQueryString, updatedQueryItem);
+    cachedQueries.set(trimmedQueryString, queryItem);
   });
   const trimmedQueryString = getTrimmedQuery(item.queryString);
 

--- a/packages/kbn-esql-editor/src/history_local_storage.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.ts
@@ -29,7 +29,7 @@ export const getTrimmedQuery = (queryString: string) => {
 
 const sortDates = (date1?: string, date2?: string) => {
   if (!date1 || !date2) return 0;
-  return date1 < date2 ? -1 : date1 > date2 ? 1 : 0;
+  return date1 < date2 ? 1 : date1 > date2 ? -1 : 0;
 };
 
 export const getHistoryItems = (sortDirection: 'desc' | 'asc'): QueryHistoryItem[] => {


### PR DESCRIPTION
## Summary

Uses ISO formats for the history instead of formatted time with the timezone
