### PR TITLE
[Custom threshold] add spaceId to viewInAppUrl

### DIFF
--- a/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/get_view_in_app_url.test.ts
+++ b/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/get_view_in_app_url.test.ts
@@ -59,15 +59,18 @@ describe('getViewInAppUrl', () => {
     };
 
     expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
-    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith({
-      dataset: args.dataViewId,
-      timeRange: returnedTimeRange,
-      filters: [],
-      query: {
-        query: 'mockedFilter and mockedCountFilter',
-        language: 'kuery',
+    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: args.dataViewId,
+        timeRange: returnedTimeRange,
+        filters: [],
+        query: {
+          query: 'mockedFilter and mockedCountFilter',
+          language: 'kuery',
+        },
       },
-    });
+      {}
+    );
   });
 
   it('should call getRedirectUrl with only count filter', () => {
@@ -85,15 +88,18 @@ describe('getViewInAppUrl', () => {
     };
 
     expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
-    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith({
-      dataset: undefined,
-      timeRange: returnedTimeRange,
-      filters: [],
-      query: {
-        query: 'mockedCountFilter',
-        language: 'kuery',
+    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: undefined,
+        timeRange: returnedTimeRange,
+        filters: [],
+        query: {
+          query: 'mockedCountFilter',
+          language: 'kuery',
+        },
       },
-    });
+      {}
+    );
   });
 
   it('should call getRedirectUrl with only filter', () => {
@@ -111,15 +117,18 @@ describe('getViewInAppUrl', () => {
     };
 
     expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
-    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith({
-      dataset: undefined,
-      timeRange: returnedTimeRange,
-      filters: [],
-      query: {
-        query: 'mockedFilter',
-        language: 'kuery',
+    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: undefined,
+        timeRange: returnedTimeRange,
+        filters: [],
+        query: {
+          query: 'mockedFilter',
+          language: 'kuery',
+        },
       },
-    });
+      {}
+    );
   });
 
   it('should call getRedirectUrl with empty query if metrics and filter are not not provided', () => {
@@ -130,15 +139,18 @@ describe('getViewInAppUrl', () => {
     };
 
     expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
-    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith({
-      dataset: undefined,
-      timeRange: returnedTimeRange,
-      filters: [],
-      query: {
-        query: '',
-        language: 'kuery',
+    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: undefined,
+        timeRange: returnedTimeRange,
+        filters: [],
+        query: {
+          query: '',
+          language: 'kuery',
+        },
       },
-    });
+      {}
+    );
   });
 
   it('should call getRedirectUrl with empty if there are multiple metrics', () => {
@@ -161,15 +173,18 @@ describe('getViewInAppUrl', () => {
     };
 
     expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
-    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith({
-      dataset: undefined,
-      timeRange: returnedTimeRange,
-      filters: [],
-      query: {
-        query: '',
-        language: 'kuery',
+    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: undefined,
+        timeRange: returnedTimeRange,
+        filters: [],
+        query: {
+          query: '',
+          language: 'kuery',
+        },
       },
-    });
+      {}
+    );
   });
 
   it('should call getRedirectUrl with filters if group and searchConfiguration filter are provided', () => {
@@ -217,33 +232,67 @@ describe('getViewInAppUrl', () => {
     };
 
     expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
-    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith({
-      dataset: undefined,
-      timeRange: returnedTimeRange,
-      filters: [
-        {
-          meta: {},
-          query: {
-            term: {
-              field: {
-                value: 'justTesting',
+    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: undefined,
+        timeRange: returnedTimeRange,
+        filters: [
+          {
+            meta: {},
+            query: {
+              term: {
+                field: {
+                  value: 'justTesting',
+                },
               },
             },
           },
-        },
-        {
-          meta: {},
-          query: {
-            match_phrase: {
-              'host.name': 'host-1',
+          {
+            meta: {},
+            query: {
+              match_phrase: {
+                'host.name': 'host-1',
+              },
             },
           },
+        ],
+        query: {
+          query: 'mockedFilter',
+          language: 'kuery',
+        },
+      },
+      {}
+    );
+  });
+
+  it('should call getRedirectUrl with spaceId', () => {
+    const spaceId = 'mockedSpaceId';
+    const args: GetViewInAppUrlArgs = {
+      metrics: [
+        {
+          name: 'A',
+          aggType: Aggregators.COUNT,
+          filter: 'mockedCountFilter',
         },
       ],
-      query: {
-        query: 'mockedFilter',
-        language: 'kuery',
+      logsExplorerLocator,
+      startedAt,
+      endedAt,
+      spaceId,
+    };
+
+    expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
+    expect(logsExplorerLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: undefined,
+        timeRange: returnedTimeRange,
+        filters: [],
+        query: {
+          query: 'mockedCountFilter',
+          language: 'kuery',
+        },
       },
-    });
+      { spaceId }
+    );
   });
 });

--- a/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/get_view_in_app_url.ts
+++ b/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/get_view_in_app_url.ts
@@ -58,11 +58,13 @@ export const getViewInAppUrl = ({
     query.query = searchConfigurationQuery;
   }
 
-  return logsExplorerLocator?.getRedirectUrl({
-    dataset,
-    timeRange,
-    query,
-    spaceId,
-    filters: [...searchConfigurationFilters, ...groupFilters],
-  });
+  return logsExplorerLocator?.getRedirectUrl(
+    {
+      dataset,
+      timeRange,
+      query,
+      filters: [...searchConfigurationFilters, ...groupFilters],
+    },
+    { spaceId }
+  );
 };

--- a/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/get_view_in_app_url.ts
+++ b/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/get_view_in_app_url.ts
@@ -22,6 +22,7 @@ export interface GetViewInAppUrlArgs {
   logsExplorerLocator?: LocatorPublic<LogsExplorerLocatorParams>;
   metrics?: CustomThresholdExpressionMetric[];
   startedAt?: string;
+  spaceId?: string;
 }
 
 export const getViewInAppUrl = ({
@@ -32,6 +33,7 @@ export const getViewInAppUrl = ({
   metrics = [],
   searchConfiguration,
   startedAt = new Date().toISOString(),
+  spaceId,
 }: GetViewInAppUrlArgs) => {
   if (!logsExplorerLocator) return '';
 
@@ -60,6 +62,7 @@ export const getViewInAppUrl = ({
     dataset,
     timeRange,
     query,
+    spaceId,
     filters: [...searchConfigurationFilters, ...groupFilters],
   });
 };

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
@@ -285,6 +285,7 @@ export const createCustomThresholdExecutor = ({
               metrics: alertResults.length === 1 ? alertResults[0][group].metrics : [],
               searchConfiguration: params.searchConfiguration,
               startedAt: indexedStartedAt,
+              spaceId,
             }),
             ...additionalContext,
           },

--- a/x-pack/test/api_integration/deployment_agnostic/services/alerting_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/alerting_api.ts
@@ -942,14 +942,16 @@ export function AlertingApiProvider({ getService }: DeploymentAgnosticFtrProvide
       ruleId,
       expectedStatus,
       roleAuthc,
+      spaceId,
     }: {
       ruleId: string;
       expectedStatus: string;
       roleAuthc: RoleCredentials;
+      spaceId?: string;
     }) {
       return await retry.tryForTime(retryTimeout, async () => {
         const response = await supertestWithoutAuth
-          .get(`/api/alerting/rule/${ruleId}`)
+          .get(`${spaceId ? '/s/' + spaceId : ''}/api/alerting/rule/${ruleId}`)
           .set(roleAuthc.apiKeyHeader)
           .set(samlAuth.getInternalRequestHeader())
           .timeout(requestTimeout);
@@ -1034,13 +1036,15 @@ export function AlertingApiProvider({ getService }: DeploymentAgnosticFtrProvide
       name,
       indexName,
       roleAuthc,
+      spaceId,
     }: {
       name: string;
       indexName: string;
       roleAuthc: RoleCredentials;
+      spaceId?: string;
     }) {
       const { body } = await supertestWithoutAuth
-        .post(`/api/actions/connector`)
+        .post(`${spaceId ? '/s/' + spaceId : ''}/api/actions/connector`)
         .set(roleAuthc.apiKeyHeader)
         .set(samlAuth.getInternalRequestHeader())
         .send({
@@ -1063,6 +1067,7 @@ export function AlertingApiProvider({ getService }: DeploymentAgnosticFtrProvide
       schedule,
       consumer,
       roleAuthc,
+      spaceId,
     }: {
       ruleTypeId: string;
       name: string;
@@ -1080,9 +1085,10 @@ export function AlertingApiProvider({ getService }: DeploymentAgnosticFtrProvide
       schedule?: { interval: string };
       consumer: string;
       roleAuthc: RoleCredentials;
+      spaceId?: string;
     }) {
       const { body } = await supertestWithoutAuth
-        .post(`/api/alerting/rule`)
+        .post(`${spaceId ? '/s/' + spaceId : ''}/api/alerting/rule`)
         .set(roleAuthc.apiKeyHeader)
         .set(samlAuth.getInternalRequestHeader())
         .send({

--- a/x-pack/test/api_integration/deployment_agnostic/services/data_view_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/data_view_api.ts
@@ -18,14 +18,16 @@ export function DataViewApiProvider({ getService }: DeploymentAgnosticFtrProvide
       id,
       name,
       title,
+      spaceId,
     }: {
       roleAuthc: RoleCredentials;
       id: string;
       name: string;
       title: string;
+      spaceId?: string;
     }) {
       const { body } = await supertestWithoutAuth
-        .post(`/api/content_management/rpc/create`)
+        .post(`${spaceId ? '/s/' + spaceId : ''}/api/content_management/rpc/create`)
         .set(roleAuthc.apiKeyHeader)
         .set(samlAuth.getInternalRequestHeader())
         .set(samlAuth.getCommonRequestHeader())
@@ -48,9 +50,17 @@ export function DataViewApiProvider({ getService }: DeploymentAgnosticFtrProvide
       return body;
     },
 
-    async delete({ roleAuthc, id }: { roleAuthc: RoleCredentials; id: string }) {
+    async delete({
+      roleAuthc,
+      id,
+      spaceId,
+    }: {
+      roleAuthc: RoleCredentials;
+      id: string;
+      spaceId?: string;
+    }) {
       const { body } = await supertestWithoutAuth
-        .post(`/api/content_management/rpc/delete`)
+        .post(`${spaceId ? '/s/' + spaceId : ''}/api/content_management/rpc/delete`)
         .set(roleAuthc.apiKeyHeader)
         .set(samlAuth.getInternalRequestHeader())
         .set(samlAuth.getCommonRequestHeader())

--- a/x-pack/test/api_integration/deployment_agnostic/services/deployment_agnostic_services.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/deployment_agnostic_services.ts
@@ -26,4 +26,5 @@ export const deploymentAgnosticServices = _.pick(apiIntegrationServices, [
   'retry',
   'security',
   'usageAPI',
+  'spaces',
 ]);


### PR DESCRIPTION
## Summary

Create a custom threshold rule as described here in a space other than default:
https://github.com/elastic/kibana/blob/main/x-pack/plugins/observability_solution/observability/dev_docs/custom_threshold.md

During rule creation, add a server log connector including `[View in App]({{context.viewInAppUrl}})` as shown below.
If you want to get the log on every execution(every minute), set `On check Intervals`.

<img src="https://github.com/user-attachments/assets/5bb029e6-07ea-4881-b6f2-bd5be1c5d041" width=500 />

